### PR TITLE
Fix Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ cache:
     - vendor
     - $HOME/phpunit-bin
 
+services:
+  - mysql
+  - memcached
+
 addons:
   apt:
     packages:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php-coveralls/php-coveralls": "^2.1",
     "slowprog/composer-copy-file": "0.2.1",
     "wp-coding-standards/wpcs": "*",
-    "xwp/wp-dev-lib": "^1.1.1"
+    "xwp/wp-dev-lib": "^1.6.5"
   },
   "scripts": {
     "phpcs": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "firebase/php-jwt": "^5.0",
     "phpcompatibility/phpcompatibility-wp": "*",
-    "php-coveralls/php-coveralls": "^2.1",
+    "php-coveralls/php-coveralls": "^2.4.2",
     "slowprog/composer-copy-file": "0.2.1",
     "wp-coding-standards/wpcs": "*",
     "xwp/wp-dev-lib": "^1.6.5"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "brainmaestro/composer-git-hooks": "^2.6.0",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "firebase/php-jwt": "^5.0",
     "phpcompatibility/phpcompatibility-wp": "*",
     "php-coveralls/php-coveralls": "^2.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="jwt-auth">
 			<directory prefix="class-test-" suffix=".php">./tests/</directory>
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>

--- a/wp-admin/includes/class-wp-key-pair-list-table.php
+++ b/wp-admin/includes/class-wp-key-pair-list-table.php
@@ -73,12 +73,12 @@ class WP_Key_Pair_List_Table extends WP_List_Table {
 				if ( empty( $item['created'] ) ) {
 					return '&mdash;';
 				}
-				return date( 'F j, Y g:i a', $item['created'] );
+				return gmdate( 'F j, Y g:i a', $item['created'] );
 			case 'last_used':
 				if ( empty( $item['last_used'] ) ) {
 					return '&mdash;';
 				}
-				return date( 'F j, Y g:i a', $item['last_used'] );
+				return gmdate( 'F j, Y g:i a', $item['last_used'] );
 			case 'last_ip':
 				if ( empty( $item['last_ip'] ) ) {
 					return '&mdash;';

--- a/wp-includes/rest-api/auth/class-wp-rest-key-pair.php
+++ b/wp-includes/rest-api/auth/class-wp-rest-key-pair.php
@@ -92,17 +92,18 @@ class WP_REST_Key_Pair {
 	 */
 	public function register_routes() {
 		$args = array(
-			'methods'  => WP_REST_Server::CREATABLE,
-			'callback' => array( $this, 'generate_key_pair' ),
-			'args'     => array(
-				'name'    => array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => array( $this, 'generate_key_pair' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'name'               => array(
 					'description'       => esc_html__( 'The name of the key-pair.', 'jwt-auth' ),
 					'type'              => 'string',
 					'required'          => true,
 					'sanitize_callback' => 'sanitize_text_field',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'user_id' => array(
+				'user_id'            => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
@@ -110,15 +111,16 @@ class WP_REST_Key_Pair {
 					'validate_callback' => 'rest_validate_request_arg',
 				),
 			),
-			'schema'   => array( $this, 'get_item_schema' ),
+			'schema'              => array( $this, 'get_item_schema' ),
 		);
 		register_rest_route( self::_NAMESPACE_, '/' . self::_REST_BASE_ . '/(?P<user_id>[\d]+)', $args );
 
 		$args = array(
-			'methods'  => WP_REST_Server::DELETABLE,
-			'callback' => array( $this, 'delete_all_key_pairs' ),
-			'args'     => array(
-				'user_id' => array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => array( $this, 'delete_all_key_pairs' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'user_id'            => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
@@ -130,17 +132,18 @@ class WP_REST_Key_Pair {
 		register_rest_route( self::_NAMESPACE_, '/' . self::_REST_BASE_ . '/(?P<user_id>[\d]+)/revoke-all', $args );
 
 		$args = array(
-			'methods'  => WP_REST_Server::DELETABLE,
-			'callback' => array( $this, 'delete_key_pair' ),
-			'args'     => array(
-				'user_id' => array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => array( $this, 'delete_key_pair' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'user_id'            => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
 					'sanitize_callback' => 'absint',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'api_key' => array(
+				'api_key'            => array(
 					'description'       => esc_html__( 'The API key being revoked.', 'jwt-auth' ),
 					'type'              => 'string',
 					'required'          => true,

--- a/wp-includes/rest-api/auth/class-wp-rest-key-pair.php
+++ b/wp-includes/rest-api/auth/class-wp-rest-key-pair.php
@@ -96,14 +96,14 @@ class WP_REST_Key_Pair {
 			'callback'            => array( $this, 'generate_key_pair' ),
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'name'               => array(
+				'name'    => array(
 					'description'       => esc_html__( 'The name of the key-pair.', 'jwt-auth' ),
 					'type'              => 'string',
 					'required'          => true,
 					'sanitize_callback' => 'sanitize_text_field',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'user_id'            => array(
+				'user_id' => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
@@ -120,7 +120,7 @@ class WP_REST_Key_Pair {
 			'callback'            => array( $this, 'delete_all_key_pairs' ),
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'user_id'            => array(
+				'user_id' => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
@@ -136,14 +136,14 @@ class WP_REST_Key_Pair {
 			'callback'            => array( $this, 'delete_key_pair' ),
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'user_id'            => array(
+				'user_id' => array(
 					'description'       => esc_html__( 'The ID of the user.', 'jwt-auth' ),
 					'type'              => 'integer',
 					'required'          => true,
 					'sanitize_callback' => 'absint',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'api_key'            => array(
+				'api_key' => array(
 					'description'       => esc_html__( 'The API key being revoked.', 'jwt-auth' ),
 					'type'              => 'string',
 					'required'          => true,
@@ -517,7 +517,7 @@ class WP_REST_Key_Pair {
 		$keypairs[] = $new_item;
 		$this->set_user_key_pairs( $user_id, $keypairs );
 
-		$new_item['created']   = date( 'F j, Y g:i a', $new_item['created'] );
+		$new_item['created']   = gmdate( 'F j, Y g:i a', $new_item['created'] );
 		$new_item['last_used'] = '—';
 		$new_item['last_ip']   = '—';
 

--- a/wp-includes/rest-api/auth/class-wp-rest-token.php
+++ b/wp-includes/rest-api/auth/class-wp-rest-token.php
@@ -98,29 +98,31 @@ class WP_REST_Token {
 	 */
 	public function register_routes() {
 		$args = array(
-			'methods'  => WP_REST_Server::READABLE,
-			'callback' => array( $this, 'validate' ),
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => array( $this, 'validate' ),
+			'permission_callback' => '__return_true'
 		);
 		register_rest_route( self::_NAMESPACE_, '/' . self::_REST_BASE_ . '/validate', $args );
 
 		$args = array(
-			'methods'  => WP_REST_Server::CREATABLE,
-			'callback' => array( $this, 'generate_token' ),
-			'args'     => array(
-				'api_key'    => array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => array( $this, 'generate_token' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'api_key'            => array(
 					'description'       => __( 'The API key of the user; requires also setting the api_secret.', 'jwt-auth' ),
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'api_secret' => array(
+				'api_secret'         => array(
 					'description'       => __( 'The API secret of the user; requires also setting the api_key.', 'jwt-auth' ),
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
 			),
-			'schema'   => array( $this, 'get_item_schema' ),
+			'schema'              => array( $this, 'get_item_schema' ),
 		);
 		register_rest_route( self::_NAMESPACE_, '/' . self::_REST_BASE_, $args );
 	}

--- a/wp-includes/rest-api/auth/class-wp-rest-token.php
+++ b/wp-includes/rest-api/auth/class-wp-rest-token.php
@@ -100,7 +100,7 @@ class WP_REST_Token {
 		$args = array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'validate' ),
-			'permission_callback' => '__return_true'
+			'permission_callback' => '__return_true',
 		);
 		register_rest_route( self::_NAMESPACE_, '/' . self::_REST_BASE_ . '/validate', $args );
 
@@ -109,13 +109,13 @@ class WP_REST_Token {
 			'callback'            => array( $this, 'generate_token' ),
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'api_key'            => array(
+				'api_key'    => array(
 					'description'       => __( 'The API key of the user; requires also setting the api_secret.', 'jwt-auth' ),
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'validate_callback' => 'rest_validate_request_arg',
 				),
-				'api_secret'         => array(
+				'api_secret' => array(
 					'description'       => __( 'The API secret of the user; requires also setting the api_key.', 'jwt-auth' ),
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
@@ -382,8 +382,8 @@ class WP_REST_Token {
 	 */
 	public function require_token() {
 		$require_token  = true;
-		$request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( $_SERVER['REQUEST_URI'] ) : false;
-		$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( $_SERVER['REQUEST_METHOD'] ) : false;
+		$request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : false;
+		$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : false;
 
 		// User is already authenticated.
 		$user = wp_get_current_user();
@@ -777,11 +777,11 @@ class WP_REST_Token {
 	public function get_auth_header() {
 
 		// Get HTTP Authorization Header.
-		$header = isset( $_SERVER['HTTP_AUTHORIZATION'] ) ? sanitize_text_field( $_SERVER['HTTP_AUTHORIZATION'] ) : false;
+		$header = isset( $_SERVER['HTTP_AUTHORIZATION'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] ) ) : false;
 
 		// Check for alternative header.
 		if ( ! $header && isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
-			$header = sanitize_text_field( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] );
+			$header = sanitize_text_field( wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) );
 		}
 
 		// The HTTP Authorization Header is missing, return an error.


### PR DESCRIPTION
This makes several updates that fixes new WordPress warnings and brings things up to standard so that Travis builds will run.

Updates:

- Upgrade PHPCS Composer Installer to 0.7
- Update Travis config to enable mysql and memecached
- Fix permissions callbacks (#39)
- Fix PHPCS issues
- Upgrade xwp/wp-dev-lib to 1.6.5
- Upgrade php-coveralls to 2.4.2
- Fix PHPUnit configuration validation
